### PR TITLE
Remove MacOS builds from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ rust:
 # All supported OSes.
 os:
   - linux
-  - osx
 
 # Build both on i686 and x86_64, with backtrace on.
 env:


### PR DESCRIPTION
MacOS builds on Travis are taking a very long time to even start to run, thus delaying all the CI pipeline.